### PR TITLE
chore(backstage): add simple catalog-info file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-metricsgenreceiver
+  description: Buildkite Pipeline for metricsgenreceiver
+  links:
+    - title: Repository
+      url: https://buildkite.com/elastic/metricsgenreceiver


### PR DESCRIPTION
This commit is part of the onboarding of the repository to the Elastic org and is adding a basic catalog-info file.