### PR TITLE
Adds a template for the nginx receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ receivers:
       * `builtin/elasticapm-transaction-metrics`: simulates aggregated transaction metrics from the `elasticapmconnector`. The scale influences how many service instances are simulated. Uses the `template_vars` option to customize the data generation:
         * `services`: the number of services to simulate. Does not affect the number of metrics.
         * `transactions`: the number of transactions to simulate per service instance. This affects the number of simulated metrics.
+    * `builtin/nginx`: Built in scenario for nginx connection metrics simulating the `nginxreceiver`.
     * Custom scenarios:
       Expects a `<path>.json` or `<path>.yaml` and a `<path>-resource-attributes.json` or `<path>-resource-attributes.yaml` file.
       The `<path>.json`/`<path>.yaml` file contains a single batch of resource metrics in JSON or YAML format, as produced by the `fileexporter`.

--- a/metricsgenreceiver/internal/metricstmpl/builtin/nginx-resource-attributes.yaml
+++ b/metricsgenreceiver/internal/metricstmpl/builtin/nginx-resource-attributes.yaml
@@ -1,6 +1,15 @@
 resourceMetrics:
   - resource:
       attributes:
-        - { key: host.name, value: { stringValue: "nginx-host-{{.InstanceID}}" } }
-        - { key: service.name, value: { stringValue: "nginx" } }
-        - { key: service.instance.id, value: { stringValue: "{{.InstanceID}}" } }
+        - key: host.name
+          value:
+            stringValue: "nginx-host-{{.InstanceID}}"
+        - key: service.name
+          value:
+            stringValue: "nginx"
+        - key: host.ip
+          value:
+            arrayValue:
+              values:
+                - stringValue: "{{.RandomIPv4}}"
+                - stringValue: "{{.RandomIPv6}}"

--- a/metricsgenreceiver/internal/metricstmpl/builtin/nginx-resource-attributes.yaml
+++ b/metricsgenreceiver/internal/metricstmpl/builtin/nginx-resource-attributes.yaml
@@ -1,0 +1,6 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - { key: host.name, value: { stringValue: "nginx-host-{{.InstanceID}}" } }
+        - { key: service.name, value: { stringValue: "nginx" } }
+        - { key: service.instance.id, value: { stringValue: "{{.InstanceID}}" } }

--- a/metricsgenreceiver/internal/metricstmpl/builtin/nginx.yaml
+++ b/metricsgenreceiver/internal/metricstmpl/builtin/nginx.yaml
@@ -2,9 +2,9 @@
 resourceMetrics:
   - resource:
         attributes:
-          - key: host.id
+          - key: host.name
             value:
-              stringValue: "host-{{.InstanceID}}"
+              stringValue: "nginx-host"
           - key: service.name
             value:
                stringValue: "nginx"
@@ -12,8 +12,7 @@ resourceMetrics:
             value:
               arrayValue:
                 values:
-                  - stringValue: "{{.RandomIPv4}}"
-                  - stringValue: "{{.RandomIPv6}}"
+                  - stringValue: "172.18.0.2"
     scopeMetrics:
       - scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver

--- a/metricsgenreceiver/internal/metricstmpl/builtin/nginx.yaml
+++ b/metricsgenreceiver/internal/metricstmpl/builtin/nginx.yaml
@@ -1,6 +1,19 @@
 # Nginx status metrics
 resourceMetrics:
-  - resource: {}
+  - resource:
+        attributes:
+          - key: host.id
+            value:
+              stringValue: "host-{{.InstanceID}}"
+          - key: service.name
+            value:
+               stringValue: "nginx"
+          - key: host.ip
+            value:
+              arrayValue:
+                values:
+                  - stringValue: "{{.RandomIPv4}}"
+                  - stringValue: "{{.RandomIPv6}}"
     scopeMetrics:
       - scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver

--- a/metricsgenreceiver/internal/metricstmpl/builtin/nginx.yaml
+++ b/metricsgenreceiver/internal/metricstmpl/builtin/nginx.yaml
@@ -1,0 +1,72 @@
+# Nginx status metrics
+resourceMetrics:
+  - resource: {}
+    scopeMetrics:
+      - scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver
+          version: 0.126.0
+        metrics:
+          - name: nginx.connections_accepted
+            description: The total number of accepted client connections
+            unit: connections
+            sum:
+              dataPoints:
+                - startTimeUnixNano: "0"
+                  timeUnixNano: "0"
+                  asInt: "0"
+              aggregationTemporality: 2
+              isMonotonic: true
+          - name: nginx.connections_current
+            description: The current number of nginx connections by state
+            unit: connections
+            sum:
+              dataPoints:
+                - attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                  startTimeUnixNano: "0"
+                  timeUnixNano: "0"
+                  asInt: "0"
+                - attributes:
+                    - key: state
+                      value:
+                        stringValue: reading
+                  startTimeUnixNano: "0"
+                  timeUnixNano: "0"
+                  asInt: "0"
+                - attributes:
+                    - key: state
+                      value:
+                        stringValue: writing
+                  startTimeUnixNano: "0"
+                  timeUnixNano: "0"
+                  asInt: "0"
+                - attributes:
+                    - key: state
+                      value:
+                        stringValue: waiting
+                  startTimeUnixNano: "0"
+                  timeUnixNano: "0"
+                  asInt: "0"
+              aggregationTemporality: 2
+          - name: nginx.connections_handled
+            description: The total number of handled connections. Generally, the parameter value is the same as nginx.connections_accepted unless some resource limits have been reached (for example, the worker_connections limit).
+            unit: connections
+            sum:
+              dataPoints:
+                - startTimeUnixNano: "0"
+                  timeUnixNano: "0"
+                  asInt: "0"
+              aggregationTemporality: 2
+              isMonotonic: true
+          - name: nginx.requests
+            description: Total number of requests made to the server since it started
+            unit: requests
+            sum:
+              dataPoints:
+                - startTimeUnixNano: "0"
+                  timeUnixNano: "0"
+                  asInt: "0"
+              aggregationTemporality: 2
+              isMonotonic: true


### PR DESCRIPTION
This is a built in template for nginx. It was built based on the following event

```
{
  "resourceMetrics": [
    {
      "resource": {},
      "scopeMetrics": [
        {
          "scope": {
            "name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver",
            "version": "0.126.0"
          },
          "metrics": [
            {
              "name": "nginx.connections_accepted",
              "description": "The total number of accepted client connections",
              "unit": "connections",
              "sum": {
                "dataPoints": [
                  {
                    "startTimeUnixNano": "1747656709833853428",
                    "timeUnixNano": "1747656790838071840",
                    "asInt": "17"
                  }
                ],
                "aggregationTemporality": 2,
                "isMonotonic": true
              }
            },
            {
              "name": "nginx.connections_current",
              "description": "The current number of nginx connections by state",
              "unit": "connections",
              "sum": {
                "dataPoints": [
                  {
                    "attributes": [
                      {
                        "key": "state",
                        "value": {
                          "stringValue": "active"
                        }
                      }
                    ],
                    "startTimeUnixNano": "1747656709833853428",
                    "timeUnixNano": "1747656790838071840",
                    "asInt": "9"
                  },
                  {
                    "attributes": [
                      {
                        "key": "state",
                        "value": {
                          "stringValue": "reading"
                        }
                      }
                    ],
                    "startTimeUnixNano": "1747656709833853428",
                    "timeUnixNano": "1747656790838071840",
                    "asInt": "0"
                  },
                  {
                    "attributes": [
                      {
                        "key": "state",
                        "value": {
                          "stringValue": "writing"
                        }
                      }
                    ],
                    "startTimeUnixNano": "1747656709833853428",
                    "timeUnixNano": "1747656790838071840",
                    "asInt": "1"
                  },
                  {
                    "attributes": [
                      {
                        "key": "state",
                        "value": {
                          "stringValue": "waiting"
                        }
                      }
                    ],
                    "startTimeUnixNano": "1747656709833853428",
                    "timeUnixNano": "1747656790838071840",
                    "asInt": "8"
                  }
                ],
                "aggregationTemporality": 2
              }
            },
            {
              "name": "nginx.connections_handled",
              "description": "The total number of handled connections. Generally, the parameter value is the same as nginx.connections_accepted unless some resource limits have been reached (for example, the worker_connections limit).",
              "unit": "connections",
              "sum": {
                "dataPoints": [
                  {
                    "startTimeUnixNano": "1747656709833853428",
                    "timeUnixNano": "1747656790838071840",
                    "asInt": "17"
                  }
                ],
                "aggregationTemporality": 2,
                "isMonotonic": true
              }
            },
            {
              "name": "nginx.requests",
              "description": "Total number of requests made to the server since it started",
              "unit": "requests",
              "sum": {
                "dataPoints": [
                  {
                    "startTimeUnixNano": "1747656709833853428",
                    "timeUnixNano": "1747656790838071840",
                    "asInt": "947"
                  }
                ],
                "aggregationTemporality": 2,
                "isMonotonic": true
              }
            }
          ]
        }
      ]
    }
  ]
}
```

add more content