### PR TITLE
refactor(metrics): print summary metrics on shutdown

### DIFF
--- a/metricsgenreceiver/receiver.go
+++ b/metricsgenreceiver/receiver.go
@@ -45,13 +45,13 @@ type Scenario struct {
 type MetricsProgress struct {
 	Start      time.Time
 	End        time.Time
-	Datapoints uint64
+	Datapoints atomic.Uint64
 }
 
 func newMetricsProgress() *MetricsProgress {
 	return &MetricsProgress{
 		Start:      time.Now(),
-		Datapoints: uint64(0),
+		Datapoints: atomic.Uint64{},
 	}
 }
 
@@ -59,7 +59,7 @@ func (p *MetricsProgress) duration() time.Duration {
 	return time.Since(p.Start)
 }
 func (p *MetricsProgress) samplesPerSecond() float64 {
-	return float64(p.Datapoints) / p.duration().Seconds()
+	return float64(p.Datapoints.Load()) / p.duration().Seconds()
 }
 
 func (p *MetricsProgress) eta(progressPct float64) time.Duration {
@@ -148,13 +148,13 @@ func (r *MetricsGenReceiver) Start(ctx context.Context, host component.Host) err
 				r.settings.Logger.Info("generating metrics progress",
 					zap.Int("progress_percent", int(progressPct*100)),
 					zap.String("eta", r.progress.eta(progressPct).Round(time.Second).String()),
-					zap.Uint64("datapoints", r.progress.Datapoints),
+					zap.Uint64("datapoints", r.progress.Datapoints.Load()),
 					zap.Float64("data_points_per_second", r.progress.samplesPerSecond()),
 				)
 				nextLog = nextLog.Add(10 * time.Second)
 			}
 			simulatedTime := addJitter(currentTime, r.cfg.IntervalJitterStdDev, r.cfg.Interval)
-			r.progress.Datapoints += r.produceMetrics(ctx, simulatedTime)
+			r.progress.Datapoints.Add(r.produceMetrics(ctx, simulatedTime))
 			r.applyChurn(i, simulatedTime)
 
 			if r.cfg.RealTime {
@@ -272,7 +272,7 @@ func (r *MetricsGenReceiver) Shutdown(_ context.Context) error {
 		r.cancel()
 	}
 	r.settings.Logger.Info("finished generating metrics",
-		zap.Uint64("datapoints", r.progress.Datapoints),
+		zap.Uint64("datapoints", r.progress.Datapoints.Load()),
 		zap.String("duration", r.progress.duration().Round(time.Millisecond).String()),
 		zap.Float64("data_points_per_second", r.progress.samplesPerSecond()),
 	)

--- a/metricsgenreceiver/receiver.go
+++ b/metricsgenreceiver/receiver.go
@@ -57,7 +57,7 @@ func newMetricsProgress() *MetricsProgress {
 func (p *MetricsProgress) duration() time.Duration {
 	return time.Since(p.start)
 }
-func (p *MetricsProgress) samplesPerSecond() float64 {
+func (p *MetricsProgress) dataPointsPerSecond() float64 {
 	return float64(p.datapoints.Load()) / p.duration().Seconds()
 }
 
@@ -148,7 +148,7 @@ func (r *MetricsGenReceiver) Start(ctx context.Context, host component.Host) err
 					zap.Int("progress_percent", int(progressPct*100)),
 					zap.String("eta", r.progress.eta(progressPct).Round(time.Second).String()),
 					zap.Uint64("datapoints", r.progress.datapoints.Load()),
-					zap.Float64("data_points_per_second", r.progress.samplesPerSecond()),
+					zap.Float64("data_points_per_second", r.progress.dataPointsPerSecond()),
 				)
 				nextLog = nextLog.Add(10 * time.Second)
 			}
@@ -273,7 +273,7 @@ func (r *MetricsGenReceiver) Shutdown(_ context.Context) error {
 	r.settings.Logger.Info("finished generating metrics",
 		zap.Uint64("datapoints", r.progress.datapoints.Load()),
 		zap.String("duration", r.progress.duration().Round(time.Millisecond).String()),
-		zap.Float64("data_points_per_second", r.progress.samplesPerSecond()),
+		zap.Float64("data_points_per_second", r.progress.dataPointsPerSecond()),
 	)
 	return nil
 }

--- a/metricsgenreceiver/receiver.go
+++ b/metricsgenreceiver/receiver.go
@@ -124,13 +124,13 @@ func newMetricsGenReceiver(cfg *Config, set receiver.Settings) (*MetricsGenRecei
 		baseRand:  baseRand,
 		obsreport: obsreport,
 		scenarios: scenarios,
+		progress:  newMetricsProgress(),
 	}, nil
 }
 
 func (r *MetricsGenReceiver) Start(ctx context.Context, host component.Host) error {
 	ctx, cancel := context.WithCancel(ctx)
 	r.cancel = cancel
-	r.progress = newMetricsProgress()
 	go func() {
 		nextLog := r.progress.Start.Add(10 * time.Second)
 		ticker := time.NewTicker(r.cfg.Interval)

--- a/metricsgenreceiver/receiver.go
+++ b/metricsgenreceiver/receiver.go
@@ -63,6 +63,9 @@ func (p *MetricsProgress) samplesPerSecond() float64 {
 }
 
 func (p *MetricsProgress) eta(progressPct float64) time.Duration {
+	if progressPct == 0 {
+		return time.Duration(0)
+	}
 	return time.Duration(float64(p.duration().Nanoseconds())/progressPct) - p.duration()
 }
 


### PR DESCRIPTION
Move the logic of printing the summary metrics in the shutdown method.
The reasoning is that if the metricsgen is terminated abnormally a
graceful shutdown will occure printing the progress until that time.

Signed-off-by: Alexandros Sapranidis <alexandros@elastic.co>
