### PR TITLE
Add exit_after_end_timeout config

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ receivers:
 * `real_time` (default `false`): by default, the receiver generates the metrics as fast as possible.
   When set to true, it will pause after each cycle according to the configured `interval`.
 * `exit_after_end` (default `false`): when set to true, will terminate the collector.
+* `exit_after_end_timeout` (default `0`): timeout in case exit_after_end is set to true before the collector is terminated.
 * `seed` (default `0`): seed value for the random number generator that's used for simulating the standard distribution. The seed makes sure that the data generation is deterministic.
 * `distribution`: the datapoints for the metrics are individually simulated by advancing their initial value using a standard distribution,
   taking into account the [temporality](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#temporality),

--- a/metricsgenreceiver/config.go
+++ b/metricsgenreceiver/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	IntervalJitterStdDev time.Duration                `mapstructure:"interval_jitter_std_dev"`
 	RealTime             bool                         `mapstructure:"real_time"`
 	ExitAfterEnd         bool                         `mapstructure:"exit_after_end"`
+	ExitAfterEndTimeout  time.Duration                `mapstructure:"exit_after_end_timeout"`
 	Seed                 int64                        `mapstructure:"seed"`
 	Scenarios            []ScenarioCfg                `mapstructure:"scenarios"`
 	Distribution         distribution.DistributionCfg `mapstructure:"distribution"`

--- a/metricsgenreceiver/receiver.go
+++ b/metricsgenreceiver/receiver.go
@@ -162,6 +162,16 @@ func (r *MetricsGenReceiver) Start(ctx context.Context, host component.Host) err
 			currentTime = currentTime.Add(r.cfg.Interval)
 		}
 		if r.cfg.ExitAfterEnd {
+			// After the runner has finished generating metrics, we wait for the configured duration before exiting.
+			if r.cfg.ExitAfterEndTimeout != 0 {
+				r.settings.Logger.Info("finished generating metrics, waiting before exiting",
+					zap.Duration("exit_after_end_timeout", r.cfg.ExitAfterEndTimeout),
+				)
+				time.Sleep(r.cfg.ExitAfterEndTimeout)
+			} else {
+				r.settings.Logger.Info("finished generating metrics, exiting immediately")
+			}
+
 			componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(errors.New("exiting because exit_after_end is set to true")))
 		}
 	}()


### PR DESCRIPTION
This change adds a config setting exit_after_end_timeout which can be set in combination with exit_after_end. In case it is set, an additional timeout is added after the metrics generation is completed. This helps in the scenario where the metricsgenreceiver is only running for a very short time and is shutting down too quickly to collect additional metrics.