### PR TITLE
Add filelogreceiver to the build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ ocb
 
 # Ignore the development config file
 otelcol.dev.yaml
+
+# Ignore .DS_Store files
+.DS_Store

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -19,6 +19,7 @@ processors:
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver v0.127.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.127.0
   - gomod: github.com/elastic/metricsgenreceiver/metricsgenreceiver v0.127.0
     import: github.com/elastic/metricsgenreceiver/metricsgenreceiver
     name: 'metricsgenreceiver'


### PR DESCRIPTION
Having the filelogreceiver is convenient for some additional testing and allows to expand some of the tests into logs. To fully expand into logs, we likely should create eventually a fork of metricsgenreceiver or rename it. This is a quick fix to start playing around with logs.