### PR TITLE
feat(exporter): add opensearch to the exporters

### DIFF
--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -10,6 +10,7 @@ exporters:
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.134.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.134.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter v0.134.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter v0.134.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.134.0
 
 processors:


### PR DESCRIPTION
This will allow us to start metricsgen and use the OpenSearch exporter